### PR TITLE
Allow user-specified delimiter for markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The plugin offers several configuration options that you can set in your
 # LaTeX code.
 # KATEX_PREAMBLE = None
 
+# Change the delimiter character for markdown files:
+#
+# KATEX_MD_DELIMITER = ‘$’
+
 # Here you can pass a dictionary of default options that you want to run
 # KaTeX with. All possible options are listed on KaTeX's options page,
 # https://katex.org/docs/options.html.

--- a/pelican_katex/plugin.py
+++ b/pelican_katex/plugin.py
@@ -43,7 +43,8 @@ def configure_pelican(plc):
 
     # Integrate into markdown
     if markdown_available:
-        plc.settings["MARKDOWN"].setdefault("extensions", []).append(KatexExtension())
+        mdext = KatexExtension(delimiter=plc.settings.get("KATEX_MD_DELIMITER", '$'))
+        plc.settings["MARKDOWN"].setdefault("extensions", []).append(mdext)
 
 
 def reset_preamble(*args, **kwargs):

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -68,3 +68,25 @@ def test_backslash_escapes_double_dollar_delimiter():
     target = input.replace("\\", "")
     template = HTMLTemplate(f"<p>{target}</p>")
     assert template == output
+
+def test_changed_delimiter_inline():
+    ext = KatexExtension(delimiter='~')
+    input = "Hello ~x^2~ world!"
+    output = markdown.markdown(input, extensions=[ext])
+    template = HTMLTemplate('<p>Hello <span class="katex">...</span> world!</p>')
+    assert template == output
+
+def test_changed_delimiter_displaymode():
+    ext = KatexExtension(delimiter='~')
+    input = "~~x^2~~"
+    output = markdown.markdown(input, extensions=[ext])
+    template = HTMLTemplate('<p><span class="katex-display">...</span></p>')
+    assert template == output
+
+def test_changed_delimiter_escape():
+    ext = KatexExtension(delimiter='~')
+    input = r"There are \~900 pages in this book"
+    output = markdown.markdown(input, extensions=[ext])
+    target = input.replace("\\", "")
+    template = HTMLTemplate(f"<p>{target}</p>")
+    assert template == output


### PR DESCRIPTION
This allows changing the markdown delimiter via a configuration option. E.g. at the moment I'm using a unicode symbol that I know will be unused in any of my inputs, eliminating the need to escape anything.

It doesn't take separate options for inline and display modes, it just assumes that the doubled delimiter indicates display. I'm not sure if that's the right way to do it. It feels like there should be a BlockProcessor for display mode and InlineProcessor otherwise, with distinct delimiters for each. But I don't know much about latex nor what displaymode actually does, so I left things structurally alone.